### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Travis Lane
 maintainer=Travis
 sentence=A library to control some Bluetooth modules.
 paragraph=A library to control some Bluetooth modules.
+category=Communication
 url=https://github.com/Coderlane/arduino-bluetooth
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library Bluetooth is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format