### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,11 +1,11 @@
-HardwareBluetooth KEYWORD1
-SoftwareBluetooth KEYWORD1
-HardwareBluetoothRN42 KEYWORD1
-SoftwareBluetoothRN42 KEYWORD1
-TestBluetooth KEYWORD1
+HardwareBluetooth	KEYWORD1
+SoftwareBluetooth	KEYWORD1
+HardwareBluetoothRN42	KEYWORD1
+SoftwareBluetoothRN42	KEYWORD1
+TestBluetooth	KEYWORD1
 
-setup KEYWORD2
-connected KEYWORD2
-getPin KEYWORD2
-getName KEYWORD2
-getMode KEYWORD2
+setup	KEYWORD2
+connected	KEYWORD2
+getPin	KEYWORD2
+getName	KEYWORD2
+getMode	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords